### PR TITLE
[feat] 날짜에 맞는 지출 내역 조회 API 추가

### DIFF
--- a/src/main/java/com/sunny/backend/controller/ConsumptionController.java
+++ b/src/main/java/com/sunny/backend/controller/ConsumptionController.java
@@ -11,8 +11,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Tag(name="4. Consumption", description = "Consumption API")
 @RestController
@@ -41,5 +44,15 @@ public class ConsumptionController {
     @GetMapping("/spendTypeStatistics")
     public ResponseEntity<CommonResponse.ListResponse> getSpendTypeStatistics() {
         return ResponseEntity.ok().body(consumptionService.getSpendTypeStatistics());
+    }
+
+    @ApiOperation(tags = "5. Consumption", value = "날짜에 맞는 지출 내역 조회")
+    //지출 내역
+
+    @GetMapping("/date")
+
+    public ResponseEntity<CommonResponse.ListResponse>getDetailConsumption (@AuthUser CustomUserPrincipal customUserPrincipal,
+                                                                            @RequestParam("datefield") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate datefield) {
+        return ResponseEntity.ok().body(consumptionService.getDetailConsumption(customUserPrincipal,datefield));
     }
 }

--- a/src/main/java/com/sunny/backend/dto/request/consumption/ConsumptionRequest.java
+++ b/src/main/java/com/sunny/backend/dto/request/consumption/ConsumptionRequest.java
@@ -19,19 +19,6 @@ public class ConsumptionRequest {
 
     private LocalDate dateField; // 지출 일자
 
-    // public Date getParsedDateField() {
-    //     try {
-    //         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    //         return dateFormat.parse(dateField.split(" ")[0]);
-    //     } catch (ParseException e) {
-    //         // Handle date parsing exception, or return null/throw exception based on your requirement
-    //         return null;
-    //     }
-    // }
-    //
-    // public void setDateField(String dateField) {
-    //     this.dateField = dateField;
-    // }
 }
 
 

--- a/src/main/java/com/sunny/backend/dto/response/consumption/ConsumptionResponse.java
+++ b/src/main/java/com/sunny/backend/dto/response/consumption/ConsumptionResponse.java
@@ -5,7 +5,6 @@ import com.sunny.backend.entity.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,4 +33,23 @@ public class ConsumptionResponse {
                 .collect(Collectors.toList());
     }
 
+    @Getter
+    public static class DetailConsumption {
+        private String name; //지출명
+        private Long money; //지출 금액
+
+        public DetailConsumption(Consumption consumption) {
+            this.name=consumption.getName();
+            this.money = consumption.getMoney();
+        }
+
+        public static List<ConsumptionResponse.DetailConsumption> fromDetailConsumptions(List<Consumption> consumptions) {
+            return consumptions.stream()
+                    .map(ConsumptionResponse.DetailConsumption::new)
+                    .collect(Collectors.toList());
+        }
+    }
+
+
 }
+

--- a/src/main/java/com/sunny/backend/entity/Consumption.java
+++ b/src/main/java/com/sunny/backend/entity/Consumption.java
@@ -36,7 +36,8 @@ public class Consumption {
 
     @Column
     @NotNull
-    private LocalDate dateField; //string으로 등록?
+    private LocalDate dateField;
+
 
     //users 다대일 관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/sunny/backend/repository/consumption/ConsumptionRepository.java
+++ b/src/main/java/com/sunny/backend/repository/consumption/ConsumptionRepository.java
@@ -4,9 +4,9 @@ import com.sunny.backend.entity.Consumption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 
 public interface ConsumptionRepository  extends JpaRepository<Consumption,Long>, ConsumptionCustomRepository {
     List<Consumption> findByUsersId(Long userId);
+    List<Consumption> findByUsersIdAndDateField (Long userId, LocalDate datefield);
 }

--- a/src/main/java/com/sunny/backend/repository/consumption/ConsumptionRepositoryImpl.java
+++ b/src/main/java/com/sunny/backend/repository/consumption/ConsumptionRepositoryImpl.java
@@ -61,10 +61,10 @@ public class ConsumptionRepositoryImpl  extends QuerydslRepositorySupport implem
     @Override
     public Long getComsumptionMoney(Long id, LocalDate startDate, LocalDate endDate) {
         return queryFactory.select(consumption.money.sum())
-            .from(consumption)
-            .join(users).on(users.id.eq(consumption.users.id))
-            .where(consumption.dateField.between(startDate, endDate))
-            .fetchOne();
+                .from(consumption)
+                .join(users).on(users.id.eq(consumption.users.id))
+                .where(consumption.dateField.between(startDate, endDate))
+                .fetchOne();
     }
 
     private long getTotalSpending() {

--- a/src/main/java/com/sunny/backend/service/consumption/ConsumptionService.java
+++ b/src/main/java/com/sunny/backend/service/consumption/ConsumptionService.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -49,7 +50,6 @@ public class ConsumptionService {
         return responseService.getSingleResponse(HttpStatus.OK.value(),new ConsumptionResponse(consumption),"지출을 등록했습니다.");
     }
 
-
     @Transactional
     //지출 조회
     public CommonResponse.ListResponse getConsumptionList(CustomUserPrincipal customUserPrincipal) {
@@ -66,6 +66,17 @@ public class ConsumptionService {
     public CommonResponse.ListResponse getSpendTypeStatistics() {
         List<SpendTypeStatisticsResponse> statistics = consumptionRepository.getSpendTypeStatistics();
         return responseService.getListResponse(HttpStatus.OK.value(), statistics,"지출 통계 내역을 불러왔습니다.");
+    }
+
+    @Transactional
+    //지출 내역 조회
+    public CommonResponse.ListResponse getDetailConsumption(CustomUserPrincipal customUserPrincipal, LocalDate datefield) {
+
+        List<Consumption> detailConsumption =
+                consumptionRepository.findByUsersIdAndDateField(customUserPrincipal.getUsers().getId(),datefield);
+
+        List<ConsumptionResponse.DetailConsumption> detailConsumptions = ConsumptionResponse.DetailConsumption.fromDetailConsumptions(detailConsumption);
+        return responseService.getListResponse(HttpStatus.OK.value(), detailConsumptions,datefield+" 에 맞는 지출 내역을 불러왔습니다.");
     }
 
 }


### PR DESCRIPTION
## PR 타이틀
해당 날짜에 소비한 지출 내역 조회 API 추가
### PR 생성 날짜
* 2023-11-24

### PR 내용
해당 날짜에 소비한 지출 내역 조회 API 추가

### 추후 refactoring 
- response 코드 중복이 많은 것 같아서 중복 코드를 최소화 하고 싶음
- 모듈화하고 싶은데 어떻게 해야 할 지 논의하고자 함