### PR TITLE
Refactor/save

### DIFF
--- a/src/main/java/com/sunny/backend/save/domain/Save.java
+++ b/src/main/java/com/sunny/backend/save/domain/Save.java
@@ -50,7 +50,7 @@ public class Save {
 
     public long calculateRemainingDays(Save save) {
         LocalDate currentDate = LocalDate.now();
-        return ChronoUnit.DAYS.between(currentDate, save.getEndDate());
+        return ChronoUnit.DAYS.between(currentDate, save.getEndDate())+1;
     }
 
     public double calculateSavePercentage(Long userMoney, Save save) {

--- a/src/main/java/com/sunny/backend/save/service/SaveService.java
+++ b/src/main/java/com/sunny/backend/save/service/SaveService.java
@@ -55,21 +55,18 @@ public class SaveService {
 		return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse, "절약 목표를 수정했습니다.");
 	}
 
-	@Transactional
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> getSaveGoal(
-			CustomUserPrincipal customUserPrincipal) {
-		Users user = customUserPrincipal.getUsers();
-		Save save = saveRepository.findByUsers_Id(user.getId());
-		SaveResponse saveResponse = SaveResponse.from(save);
-		return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse,
-				"절약 목표를 성공적으로 조회했습니다.");
-	}
+
 
 	@Transactional
 	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse.DetailSaveResponse>>
 	getDetailSaveGoal(CustomUserPrincipal customUserPrincipal) {
 		Users user = customUserPrincipal.getUsers();
 		Save save = saveRepository.findByUsers_Id(user.getId());
+		if(save==null){
+			return responseService.getSingleResponse(HttpStatus.OK.value(), null,
+					"아직 등록된 절약 목표가 없습니다.");
+
+		}
 		long remainingDays = save.calculateRemainingDays(save);
 		Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(),
 				save.getEndDate());


### PR DESCRIPTION
## PR 타이틀
Refactor/save
### PR 생성 날짜
* 2024-01-18

### PR 내용
1. save 응답 API 수정
- ex ) 기존 : 2024-01-18 ~ 2024-01-18 
         남은 날짜 : 0일
         수정 :  2024-01-18 ~ 2024-01-18 
         남은 날짜 : 1일 (계산 방식 바꿈)
2. save가 null일 경우 ( 사용자가 절약 목표를 등록하지 않았을 경우)
- 기존 방식 : save가 null인 상태에서 조회 API를 호출하고 있으므로 status 400 값 전송했음
-  수정 후 : save가 null인 상태에서 조회한다면 status 200 호출, data = null , msg : "아직 등록된 절약 목표가 없습니다."
![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/caccde60-9b54-4359-9709-0d89365934d4)
data 를 null 로 주는 이유 :   date,savePercentage를 0으로 주면 실제 데이터가 존재했을 때 경우랑 헷갈릴 수도 있을 것 같다고 생각함 (실제 남은 일수가 0, 퍼센트가 0인경우가 있을 수 있으니까 )        

프론트랑 협의 후 추후 수정이 필요할 수도 있음

3. save 수정 할 때 start_date 수정하지 못하도록 해야 함
- 프론트에서 아예 입력창을 막아놔서 기존 start_date를 보낼 지 
 -  기존 request는 수정 안해도 된다는 장점이 있음
