### PR TITLE
Refactor/community

### DIFF
--- a/src/main/java/com/sunny/backend/auth/service/KakaoService.java
+++ b/src/main/java/com/sunny/backend/auth/service/KakaoService.java
@@ -72,7 +72,7 @@ public class KakaoService {
                 kakaoTokenRequest, // 요청할 때 보낼 데이터
             OAuthToken.class // 요청 시 반환되는 데이터 타입
         );
-
+        System.out.println(response);
         return response.getBody().getAccessToken();
     }
 

--- a/src/main/java/com/sunny/backend/community/controller/CommunityController.java
+++ b/src/main/java/com/sunny/backend/community/controller/CommunityController.java
@@ -82,4 +82,11 @@ public class CommunityController {
 		return communityService.deleteCommunity(customUserPrincipal, communityId);
 	}
 
+	@ApiOperation(tags = "2. Community", value = "커뮤니티 조회수/댓글수 확인")
+	@GetMapping("/count/{communityId}")
+	public ResponseEntity<CommonResponse.SingleResponse<CommunityResponse.ViewAndCommentResponse>> getCommentAndViewByCommunity(
+			@AuthUser CustomUserPrincipal customUserPrincipal, @PathVariable Long communityId) {
+		return communityService.getCommentAndViewByCommunity(customUserPrincipal, communityId);
+	}
+
 }

--- a/src/main/java/com/sunny/backend/community/domain/Community.java
+++ b/src/main/java/com/sunny/backend/community/domain/Community.java
@@ -83,7 +83,7 @@ public class Community {
 
     public boolean hasNotBeenModified(LocalDateTime createdAt,LocalDateTime modifiedAt ) {
 
-        return createdAt.isEqual(modifiedAt);
+        return !createdAt.isEqual(modifiedAt);
     }
     public void updateModifiedAt(LocalDateTime modifiedAt ) {
 

--- a/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
+++ b/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
@@ -56,6 +56,7 @@ public record CommunityResponse(
         String writer,
         int viewCount,
         int commentCount,
+        BoardType type,
         String createdAt,
         boolean isModified
 
@@ -70,6 +71,7 @@ public record CommunityResponse(
                 community.getUsers().getName(),
                 community.getView_cnt(),
                 community.getCommentList().size(),
+                community.getBoardType(),
                 DatetimeUtil.timesAgo(community.getCreatedAt()),
                 isModified
 

--- a/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
+++ b/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
@@ -21,12 +21,14 @@ public record CommunityResponse(
     BoardType type,
     String profileImg,
     String createdAt,
+
     boolean isModified,
     boolean isScraped
 ) {
 
     public static CommunityResponse of(Community community, boolean isScraped) {
         boolean isModified = community.hasNotBeenModified(community.getCreatedAt(), community.getModifiedAt());
+
         return new CommunityResponse(
             community.getId(),
             community.getUsers().getName(),
@@ -70,6 +72,19 @@ public record CommunityResponse(
                 community.getCommentList().size(),
                 DatetimeUtil.timesAgo(community.getCreatedAt()),
                 isModified
+
+            );
+        }
+    }
+    public record ViewAndCommentResponse(
+        int viewCount,
+        int commentCount
+
+    ) {
+        public static ViewAndCommentResponse from(Community community) {
+            return new ViewAndCommentResponse(
+                community.getView_cnt(),
+                community.getCommentList().size()
 
             );
         }

--- a/src/main/java/com/sunny/backend/scrap/dto/response/ScrapResponse.java
+++ b/src/main/java/com/sunny/backend/scrap/dto/response/ScrapResponse.java
@@ -1,4 +1,4 @@
-package com.sunny.backend.user.dto;
+package com.sunny.backend.scrap.dto.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/sunny/backend/scrap/service/ScrapService.java
+++ b/src/main/java/com/sunny/backend/scrap/service/ScrapService.java
@@ -30,7 +30,6 @@ public class ScrapService {
 	private final ScrapRepository scrapRepository;
 	private final CommunityRepository communityRepository;
 	private final ResponseService responseService;
-
 	public ResponseEntity<CommonResponse.ListResponse<CommunityResponse>> getScrapsByUserId(
 		CustomUserPrincipal customUserPrincipal) {
 		Users user = customUserPrincipal.getUsers();

--- a/src/main/java/com/sunny/backend/user/controller/UserController.java
+++ b/src/main/java/com/sunny/backend/user/controller/UserController.java
@@ -17,7 +17,7 @@ import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.user.dto.ProfileResponse;
 import com.sunny.backend.comment.dto.response.CommentResponse;
 import com.sunny.backend.community.dto.response.CommunityResponse;
-import com.sunny.backend.user.dto.ScrapResponse;
+import com.sunny.backend.scrap.dto.response.ScrapResponse;
 import com.sunny.backend.user.service.UserService;
 
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/com/sunny/backend/user/service/UserService.java
+++ b/src/main/java/com/sunny/backend/user/service/UserService.java
@@ -18,7 +18,7 @@ import com.sunny.backend.comment.dto.response.CommentResponse;
 import com.sunny.backend.community.dto.response.CommunityResponse;
 import com.sunny.backend.scrap.repository.ScrapRepository;
 import com.sunny.backend.user.domain.Users;
-import com.sunny.backend.user.dto.ScrapResponse;
+import com.sunny.backend.scrap.dto.response.ScrapResponse;
 import com.sunny.backend.user.repository.UserRepository;
 import com.sunny.backend.util.S3Util;
 


### PR DESCRIPTION
## PR 타이틀
Refactor/community
### PR 생성 날짜
* 2024-01-20

### PR 내용
# 커뮤니티 게시판 조회 API

**No Offset 방식** : **조회 시작 부분을 인덱스로 빠르게 찾아** 매번 첫 페이지만 읽도록 하는 방식

- offset을 사용하지 않고 특정 Id를 기준점으로 잡아 where절을 사용하여 데이터를 조회하는 방식
- 기준점 이전의 데이터도 모두 조회하던 offset과 달리 기준점인 id부터 limit의 개수만 조회하기 때문에 데이터개수가 많아져도 성능 문제가 발생하지 않음
- 시작 위치가 어디든 첫 페이지를 읽는 것과 동일한 효과를 내게 해주는 기법
- **마지막 조회한 행의 ID값을 기준**으로 읽지 않은 행을 page size만큼 조회하면 됨
- 첫 페이지를 조회할때는 communityId 가 조건문에 없어야 하고
- 두번째 페이지부터는 communityId가 조건문에 포함되어야 함


**Offset** **방식** (일반적인 페이징): page_number에 해당하는 행만큼 데이터를 읽어들인 후 다시 Page_size만큼의 행을 읽고 앞에 읽은 행을 삭제해야 함

- 데이터가 많아질 수록 읽어야 할 데이터의 개수가 많아지고, 결국 db에 많은 부하를 줌
- 새로운 페이지를 가져오는 중간에 새로운 행이 삽입되면 새로운 페이지는 이전 페이지와 중복되는 행이 존재할 수 있음
- 페이지 번호가 커질 수록 이전에 읽었던 행을 다시 읽어야 함
    - ex. 1000번 페이지를 읽게되면 1010번까지 모두 읽게 됨
   
---

<가정>

현재 10개의 데이터가 있음 , 정렬 조건 없으면 최신순으로 나열되어 보여짐

1. 게시판 첫페이지 요청

`localhost:8080/community/board?pageSize=3`

처음에는 기준점 id를 모르니까 id 제외하고 전송 , pageSize : 한 페이지에 보여줄 데이터 개수

최근 등록된 게시글부터 3개 보여짐 (10,9,8)

그럼 프론트는 여기서 마지막 ID 값을 확인하면 됨 (8)
![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/e9beb5e4-2acc-4db9-8dbd-98f0e958763f)

2. 두 번째  페이지 요청

다음 번에 전송할 때는

`localhost:8080/community/board?pageSize=3&communityId=8`

위와 같이 기준점 Id를 전송 ( 첫 페이지에서 마지막 데이터 id 값을 보내주면 됨)

- 아니 왜 이렇게 하냐??

> 기준점 이전의 데이터도 모두 조회하던 offset과 달리 기준점인 id부터 limit의 개수만 조회하기 때문에 데이터개수가 많아져도 성능 문제가 발생하지 않음(실제로 우리도 테스트를 해봐야겠지만 여러 블로그를 참고한 결과 조회 시간이 많이 단축됨
> 
- offset 방식은 새로운 페이지를 가져오는 중간에 새로운 행이 삽입되면 새로운 페이지는 이전 페이지와 중복되는 행이 존재할 수 있음

결과 → 8번을 제외하고 7,6,5 데이터가 보여짐!

![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/a5df47c8-80fe-4fc3-a2c3-1d2fe8c6deda)

### 여기서 어떤 이슈가 발생할 수 있을까?👀

중간에 사용자가 게시글을 삭제하면 기준점인 id가 달라질 수 있음

(10,9,8)`localhost:8080/community/board?pageSize=3`

(7,6,5)`localhost:8080/community/board?pageSize=3&lastCommunityId=8`

(4,3,2)`localhost:8080/community/board?pageSize=3&lastCommunityId=5`

→위 처럼 데이터를 보여주고 있었는데 게시글 8,9번이 삭제됨

→ 아래와 같이 전송해야 됨

(10,7,6)`localhost:8080/community/board?pageSize=3`

(5,4,3)`localhost:8080/community/board?pageSize=3&lastCommunityId=6`

(2,1,)`localhost:8080/community/board?pageSize=3&lastCommunityId=3`

이건 프론트에서 조회할 때마다 검사하는 로직을 추가해야 할 것 같은데 좀만 더 생각해보겠음

이거 그냥 처음 조회할 때마다(첫 페이지) 마지막 id값 저장하고 있다가 useInfiniteQuery 로 id 날리면 될 것 같은데? 

*~~아니면 기준점을 커뮤니티 Id 값으로 잡지 말고 음.. 커뮤니티 게시글 등록 시간이라던지.. 뭔가 다른 걸로 잡으면 해결될 것 같기도 하고 (대신 unique 값으로 기준ID를 삼아야 함)~~*

---

**reference**

[[[SpringBoot] BidderOwn No offset 적용기 및 서비스 개선](https://velog.io/@leui9179/1fad3mq9)](https://velog.io/@leui9179/1fad3mq9)

첫 번째 조회가 아닌 N번째 조회 때는 lastCommunityId에 값이 들어올테니 where 조건문에서 lastCommunityId 보다 더 작은 id를 가진 post들을 기준으로 데이터들을 페이징하여 들고오도록 구현

해당 방식으로 응답한 값을 앱(React Native)에서는 React Query의 useInfiniteQuery()를 사용해서 화면에 뿌려주는 방식도 있다고 함

[[[React] React Query의 useInfiniteQuery에 대해 알아보기](https://jforj.tistory.com/246)](https://jforj.tistory.com/246)

아니면! useInfiniteQuery 사용할 수 있으면 이걸로 구현하는 것도 좋을 것 같음