### PR TITLE
[update] save response 수정

### DIFF
--- a/src/main/java/com/sunny/backend/save/domain/Save.java
+++ b/src/main/java/com/sunny/backend/save/domain/Save.java
@@ -50,7 +50,7 @@ public class Save {
 
     public long calculateRemainingDays(Save save) {
         LocalDate currentDate = LocalDate.now();
-        return ChronoUnit.DAYS.between(currentDate, save.getEndDate())+1;
+        return ChronoUnit.DAYS.between(currentDate, save.getEndDate());
     }
 
     public double calculateSavePercentage(Long userMoney, Save save) {


### PR DESCRIPTION
## PR 타이틀
save response 수정

### PR 생성 날짜
* 2024-01-20

### PR 내용
# 절약 목표 API 수정 (01.20)

1. 절약 목표(save가 null일 때 )

> 절약 목표가 없을 때 보여주는 값이 0이라서 그런건데,,. 절약 목표 없을 땐
date: 0, percentage: 0 아니었나요!?
퍼센트는 100이었나..? 절약 목표 없을 때 빈 값을 보여주진 않으니까 디폴트 값을 보내주심 될것 같아요
> 

→ 피그마 보면 Default 값은 따로 없고, 아래 그림 처럼 있더라구요 근데 default 값이 date: 0, percentage: 0 이면 안돼서,,

→ 2024.01.19~2024.01.20 일 때  (date)

- date : 2
- 1월 19일 : D-2  (D-1)
- 1월 20일 : D-1 (D-day)
- ..???????????? (D-day 표시가 안됨)

→ percentage는 목표 금액과 지출 금액이 일치하면 0%가 됨. 따라서 0 값으로 보내기엔 뭔가 애매,.
![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/b2c5eccb-db78-48f7-93d1-136e62477bf7)

→ 각각 null