### PR TITLE
[feat] 지출 통계 API 수정

### DIFF
--- a/src/main/java/com/sunny/backend/comment/domain/Comment.java
+++ b/src/main/java/com/sunny/backend/comment/domain/Comment.java
@@ -20,12 +20,12 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@DynamicInsert //동적 삽입
+@DynamicInsert
 public class Comment extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; //댓글 id
+    private Long id;
 
     @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
     @Column(name = "text", nullable = false)
@@ -33,40 +33,36 @@ public class Comment extends BaseTime {
 
     @ColumnDefault("FALSE")
     @Column(nullable = false)
-    private Boolean isDeleted; //댓글 삭제 여부
+    private Boolean isDeleted;
 
     @ColumnDefault("FALSE")
     @Column(nullable = false)
-    private Boolean isPrivated; //비밀 댓글 여부
+    private Boolean isPrivated;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="community_id")
-    private Community community; //게시글 아이디
+    private Community community;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id") //유저 아아디
+    @JoinColumn(name = "users_id")
     private Users users;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
-    private Comment parent; //부모 댓글 (null이면 최상위 댓글)
+    private Comment parent;
 
-    @OneToMany(mappedBy = "parent", orphanRemoval = true) // 부모 댓글 삭제 시 하위 댓글 모두 삭제
-    private List<Comment> children = new ArrayList<>(); //자식 댓글
-
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
 
     public Comment(String content) {
         this.content = content;
     }
-
     public void changeIsDeleted(Boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
-
     public void setContent(String content) {
         this.content=content;
     }
-
     public static void validateCommentByUser(Long userId, Long commentId) {
         if(!userId.equals(commentId)) {
             throw new CommonCustomException(NO_USER_PERMISSION);

--- a/src/main/java/com/sunny/backend/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/sunny/backend/comment/dto/request/CommentRequest.java
@@ -16,7 +16,6 @@ public class CommentRequest {
     private Long parentId;
     @NotBlank(message = "댓글 내용은 필수 입력 값입니다.")
     private String content;
-
     private Boolean isPrivated;
     public CommentRequest(String content) {
         this.content = content;

--- a/src/main/java/com/sunny/backend/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/sunny/backend/comment/dto/response/CommentResponse.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class CommentResponse {
-
 	private Long id;
 	private String content;
 	private String writer;

--- a/src/main/java/com/sunny/backend/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/sunny/backend/comment/repository/CommentCustomRepository.java
@@ -9,5 +9,4 @@ import java.util.Optional;
 public interface CommentCustomRepository {
     Optional<Comment> findCommentByIdWithParent(Long id);
     List<CommentResponse> findByCommunityId(Long id);
-
 }

--- a/src/main/java/com/sunny/backend/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sunny/backend/comment/repository/CommentRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment,Long>, CommentCustomRepository {
-
     List<Comment> findAllByUsers_Id (Long userId);
     List<Comment> findAllByCommunity_Id (Long communityId);
 }

--- a/src/main/java/com/sunny/backend/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/sunny/backend/comment/repository/CommentRepositoryImpl.java
@@ -9,9 +9,6 @@ import com.sunny.backend.comment.domain.Comment;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.*;
-
-
-
 public class CommentRepositoryImpl extends QuerydslRepositorySupport implements CommentCustomRepository{
     private JPAQueryFactory queryFactory;
 
@@ -39,10 +36,8 @@ public class CommentRepositoryImpl extends QuerydslRepositorySupport implements 
                 .orderBy(comment.parent.id.asc().nullsFirst(),
                         comment.createdDate.asc())
                 .fetch();
-
         List<CommentResponse> commentResponseDTOList = new ArrayList<>();
         Map<Long, CommentResponse> commentDTOHashMap = new HashMap<>();
-
         comments.forEach(c -> {
             CommentResponse commentResponseDTO = convertCommentToDto(c);
             commentDTOHashMap.put(commentResponseDTO.getId(), commentResponseDTO);

--- a/src/main/java/com/sunny/backend/comment/service/CommentService.java
+++ b/src/main/java/com/sunny/backend/comment/service/CommentService.java
@@ -27,12 +27,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class CommentService {
-
 	private final CommentRepository commentRepository;
 	private final CommunityRepository communityRepository;
 	private final CommentRequestMapper commentRequestMapper;
 	private final ResponseService responseService;
-
 
 	private CommentResponse mapCommentToResponse(Comment comment, Users currentUser) {
 		boolean isPrivate = comment.getIsPrivated();
@@ -78,7 +76,6 @@ public class CommentService {
 				.orElseThrow(() -> new CommonCustomException(COMMUNITY_NOT_FOUND));
 
 		Comment comment = commentRequestMapper.toEntity(commentRequestDTO);
-
 		Comment parentComment = null;
 		if (commentRequestDTO.getParentId() != null) {
 			parentComment = commentRepository.findById(commentRequestDTO.getParentId())
@@ -91,7 +88,6 @@ public class CommentService {
 		comment.setCommunity(community);
 		comment.setContent(commentRequestDTO.getContent());
 		comment.setUsers(user);
-
 		boolean isPrivate = commentRequestDTO.getIsPrivated();
 		comment.setIsPrivated(isPrivate);
 		commentRepository.save(comment);
@@ -99,7 +95,6 @@ public class CommentService {
 		return responseService.getSingleResponse(HttpStatus.OK.value(),
 				new CommentResponse(comment.getId(), comment.getUsers().getName(), comment.getContent(),
 						comment.getCreatedDate(), comment.getUpdatedDate()), "댓글을 등록했습니다.");
-
 	}
 
 	@Transactional

--- a/src/main/java/com/sunny/backend/community/controller/CommunityController.java
+++ b/src/main/java/com/sunny/backend/community/controller/CommunityController.java
@@ -44,7 +44,6 @@ public class CommunityController {
 			@RequestParam int pageSize,
 			@RequestParam(required = false) BoardType boardType,
 			@RequestParam(required = false) String search) {
-
 		return communityService.paginationNoOffsetBuilder(communityId, sortType, boardType, search,
 				pageSize);
 	}

--- a/src/main/java/com/sunny/backend/community/domain/BoardType.java
+++ b/src/main/java/com/sunny/backend/community/domain/BoardType.java
@@ -10,9 +10,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum BoardType {
 	TIP("절약 꿀팁"), FREE("자유 게시판");
-
 	private final String value;
-
 	BoardType(String value) {
 		this.value = value;
 	}
@@ -21,7 +19,6 @@ public enum BoardType {
 	public String getValue() {
 		return value;
 	}
-
 	@JsonCreator
 	public static BoardType fromValue(String value) {
 		for (BoardType type : BoardType.values()) {

--- a/src/main/java/com/sunny/backend/community/domain/Community.java
+++ b/src/main/java/com/sunny/backend/community/domain/Community.java
@@ -29,38 +29,26 @@ public class Community {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "community_id")
     private Long id;
-
     @Column
     private String title;
-
     @Column
     private String contents;
-
     @ColumnDefault("0")
     @Column
     private int viewCnt;
-
-//    @Column
-//    @ColumnDefault("false")
-//    private boolean modified;
-
     @Column
     private LocalDateTime createdAt;
     @Column
     private LocalDateTime modifiedAt;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name= "users_id")
     private Users users;
-
     @OneToMany(mappedBy = "community")
     @Builder.Default
     private List<Photo> photoList = new ArrayList<>();
-
     @Enumerated(EnumType.STRING)
     @NotNull(message = "올바른 카테고리 값을 입력해야합니다.")
     private BoardType boardType;
-
     @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<Comment> commentList=new ArrayList<>();

--- a/src/main/java/com/sunny/backend/community/domain/SortType.java
+++ b/src/main/java/com/sunny/backend/community/domain/SortType.java
@@ -10,18 +10,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum SortType {
     VIEW("조회순"), LATEST("최신순");
-
     private final String value;
-
     SortType(String value) {
         this.value = value;
     }
-
     @JsonValue
     public String getValue() {
         return value;
     }
-
     @JsonCreator
     public static SortType fromValue(String value) {
         for (SortType type : SortType.values()) {

--- a/src/main/java/com/sunny/backend/community/dto/request/CommunityRequest.java
+++ b/src/main/java/com/sunny/backend/community/dto/request/CommunityRequest.java
@@ -11,12 +11,10 @@ import lombok.NonNull;
 @Getter
 @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class CommunityRequest {
-
     @NotBlank(message = "제목은 필수 입력값입니다.")
     private String title;
     @NotBlank(message = "내용은 필수 입력값입니다.")
     private String contents;
     @NotNull(message = "올바른 카테고리 값을 입력해야합니다.")
     private BoardType type;
-
 }

--- a/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
+++ b/src/main/java/com/sunny/backend/community/dto/response/CommunityResponse.java
@@ -48,8 +48,6 @@ public record CommunityResponse(
             isScraped
         );
     }
-
-
     public record PageResponse(
         Long id,
         String title,

--- a/src/main/java/com/sunny/backend/community/repository/CommunityRepository.java
+++ b/src/main/java/com/sunny/backend/community/repository/CommunityRepository.java
@@ -11,9 +11,7 @@ import java.util.List;
 
 public interface CommunityRepository extends JpaRepository<Community, Long>,
     CommunityRepositoryCustom {
-
     List<Community> findAllByUsers_Id(Long userId);
-
     default Community getById(Long id) {
         return findById(id)
             .orElseThrow(() -> new CommonCustomException(COMMUNITY_NOT_FOUND));

--- a/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryCustom.java
+++ b/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryCustom.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 
 public interface CommunityRepositoryCustom {
-
     List<PageResponse> paginationNoOffsetBuilder(Long communityId,
         SortType sortType, BoardType boardType, String searchText, int pageSize);
 }

--- a/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryImpl.java
@@ -22,40 +22,12 @@ import org.springframework.lang.Nullable;
 
 public class CommunityRepositoryImpl extends QuerydslRepositorySupport implements
     CommunityRepositoryCustom {
-
   private final JPAQueryFactory queryFactory;
 
   public CommunityRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
     super(Community.class);
     this.queryFactory = jpaQueryFactory;
   }
-
-//  public Optional<Community> getDetailCommunity(long id){
-//    Community result=queryFactory.selectFrom(community)
-//        .where(community.id.eq(id))
-//        .join(community.users,users)
-//        .fetchJoin()
-//        .distinct()
-//        .fetchOne();
-//    return Optional.ofNullable(result);
-//  }
-//
-//  public List<Community> getSliceOfCommunity(
-//      @Nullable
-//      Long id,
-//      int size,
-//      @Nullable
-//      String keyword
-//  ) {
-//    return queryFactory.selectFrom(community)
-//        .where(ltCommunityId(id), eqSearchText(keyword))
-//        .join(community.users,users)
-//        .fetchJoin()
-//        .orderBy(community.id.desc())
-//        .limit(size)
-//        .fetch();
-//  }
-
   public List<CommunityResponse.PageResponse> paginationNoOffsetBuilder(@Nullable Long communityId,
       SortType sortType, BoardType boardType, String searchText, int pageSize) {
     JPAQuery<Community> query = queryFactory.selectFrom(community)
@@ -63,28 +35,23 @@ public class CommunityRepositoryImpl extends QuerydslRepositorySupport implement
         .orderBy(sortType == SortType.VIEW ? community.viewCnt.desc()
             : community.createdAt.desc())
         .limit(pageSize);
-
     if (searchText != null) {
       query.where(eqSearchText(searchText));
     }
     if (boardType != null) {
       query.where(eqBoardType(boardType));
     }
-
     List<Community> results = query.fetch();
-
     return results.stream()
         .map(CommunityResponse.PageResponse::from)
         .collect(Collectors.toList());
   }
-
   private BooleanExpression ltCommunityId(Long communityId) {
     if (communityId == null) {
       return null;
     }
     return community.id.lt(communityId);
   }
-
   private BooleanExpression eqSearchText(String searchText) {
     if (!searchText.isEmpty()) {
       return community.title.contains(searchText)
@@ -93,7 +60,6 @@ public class CommunityRepositoryImpl extends QuerydslRepositorySupport implement
     }
     return null;
   }
-
   private BooleanExpression eqBoardType(BoardType boardType) {
     if (boardType == BoardType.TIP) {
       return community.boardType.eq(BoardType.TIP);

--- a/src/main/java/com/sunny/backend/community/service/CommunityService.java
+++ b/src/main/java/com/sunny/backend/community/service/CommunityService.java
@@ -13,9 +13,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import com.nimbusds.oauth2.sdk.util.StringUtils;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -40,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CommunityService {
-
 	private final CommunityRepository communityRepository;
 	private final PhotoRepository photoRepository;
 	private final ScrapRepository scrapRepository;
@@ -97,7 +94,6 @@ public class CommunityService {
 				.createdAt(LocalDateTime.now())
 				.users(user)
 				.build();
-
 		if (multipartFileList != null && !multipartFileList.isEmpty()) {
 			List<Photo> photoList = new ArrayList<>();
 			for (MultipartFile multipartFile : multipartFileList) {
@@ -117,20 +113,10 @@ public class CommunityService {
 		if (user.getCommunityList() == null) {
 			user.addCommunity(community);
 		}
-
-		boolean isModified = community.hasNotBeenModified(community.getCreatedAt(), community.getModifiedAt());
-		System.out.println(isModified);
-		System.out.println(community.getModifiedAt());
-		System.out.println(community.getCreatedAt());
-
-
-
 		CommunityResponse communityResponse = CommunityResponse.of(community,  false);
 		return responseService.getSingleResponse(HttpStatus.OK.value(), communityResponse,
 				"게시글을 성공적으로 작성했습니다.");
 	}
-
-
 	@Transactional(readOnly = true)
 	public ResponseEntity<CommonResponse.SingleResponse<List<CommunityResponse.PageResponse>>> paginationNoOffsetBuilder(
 			Long communityId,
@@ -151,15 +137,12 @@ public class CommunityService {
 		community.getPhotoList().clear();
 		community.updateCommunity(communityRequest);
 		community.updateModifiedAt(LocalDateTime.now());
-
-
 		if (files != null && !files.isEmpty()) {
 			List<Photo> existingPhotos = photoRepository.findByCommunityId(communityId);
 			photoRepository.deleteAll(existingPhotos);
 			for (Photo photo : existingPhotos) {
 				s3Util.deleteFile(photo.getFileUrl());
 			}
-
 			List<Photo> photoList = new ArrayList<>();
 			for (MultipartFile multipartFile : files) {
 				Photo photo = Photo.builder()
@@ -175,21 +158,14 @@ public class CommunityService {
 		}
 		Scrap scrap = scrapRepository.findByUsersAndCommunity(user, community);
 		boolean isScrapedByCurrentUser = (scrap != null);
-		boolean isModified = community.hasNotBeenModified(community.getCreatedAt(), community.getModifiedAt());
-		System.out.println(isModified);
-		System.out.println(community.getModifiedAt());
-		System.out.println(community.getCreatedAt());
 		CommunityResponse communityResponse = CommunityResponse.of(community,
 				isScrapedByCurrentUser);
 		return responseService.getSingleResponse(HttpStatus.OK.value(), communityResponse,
 				"게시글 수정을 완료했습니다.");
 	}
-
-	//게시글 삭제
 	@Transactional
 	public ResponseEntity<CommonResponse.GeneralResponse> deleteCommunity(
 			CustomUserPrincipal customUserPrincipal, Long communityId) {
-
 		Users user = customUserPrincipal.getUsers();
 		Community community = communityRepository.getById(communityId);
 		List<Photo> photoList = photoRepository.findByCommunityId(communityId);
@@ -199,20 +175,16 @@ public class CommunityService {
 		}
 		photoRepository.deleteByCommunityId(communityId);
 		communityRepository.deleteById(communityId);
-
 		return responseService.getGeneralResponse(HttpStatus.OK.value(),
 				"게시글을 삭제했습니다.");
 	}
-
 	@Transactional
 	public ResponseEntity<CommonResponse.SingleResponse<CommunityResponse.ViewAndCommentResponse>> getCommentAndViewByCommunity(
 			CustomUserPrincipal customUserPrincipal, Long communityId) {
-
 		Users user = customUserPrincipal.getUsers();
 		Community community = communityRepository.getById(communityId);
 		ViewAndCommentResponse viewAndCommentResponse = CommunityResponse.ViewAndCommentResponse.from(community);
 		return responseService.getSingleResponse(HttpStatus.OK.value(),viewAndCommentResponse,
 				"게시글 조회수와 댓글수를 불러왔습니다.");
 	}
-
 }

--- a/src/main/java/com/sunny/backend/consumption/controller/ConsumptionController.java
+++ b/src/main/java/com/sunny/backend/consumption/controller/ConsumptionController.java
@@ -1,6 +1,7 @@
 package com.sunny.backend.consumption.controller;
 
 
+import com.sunny.backend.consumption.dto.request.YearMonthRequest;
 import com.sunny.backend.consumption.dto.response.ConsumptionResponse.DetailConsumptionResponse;
 import com.sunny.backend.consumption.domain.SpendType;
 import java.time.LocalDate;
@@ -45,8 +46,9 @@ public class ConsumptionController {
 	@ApiOperation(tags = "4. Consumption", value = "지출 통계")
 	@GetMapping("/spendTypeStatistics")
 	public ResponseEntity<CommonResponse.ListResponse<SpendTypeStatisticsResponse>>
-	getSpendTypeStatistics(@AuthUser CustomUserPrincipal customUserPrincipal) {
-		return consumptionService.getSpendTypeStatistics(customUserPrincipal);
+	getSpendTypeStatistics(@AuthUser CustomUserPrincipal customUserPrincipal,
+			@RequestBody YearMonthRequest yearMonthRequest) {
+		return consumptionService.getSpendTypeStatistics(customUserPrincipal,yearMonthRequest);
 	}
 
 	@ApiOperation(tags = "4. Consumption", value = "날짜에 맞는 지출 내역 조회")
@@ -79,7 +81,8 @@ public class ConsumptionController {
 	@GetMapping("/category")
 	public ResponseEntity<CommonResponse.ListResponse<DetailConsumptionResponse>> getConsumptionByCategory(
 			@AuthUser CustomUserPrincipal customUserPrincipal,
-			@Valid @RequestParam(required = false) SpendType spendType) {
-		return consumptionService.getConsumptionByCategory(customUserPrincipal, spendType);
+			@Valid @RequestParam(required = false) SpendType spendType,
+			@Valid @RequestBody YearMonthRequest yearMonthRequest) {
+		return consumptionService.getConsumptionByCategory(customUserPrincipal, spendType,yearMonthRequest);
 	}
 }

--- a/src/main/java/com/sunny/backend/consumption/domain/Consumption.java
+++ b/src/main/java/com/sunny/backend/consumption/domain/Consumption.java
@@ -1,22 +1,16 @@
 package com.sunny.backend.consumption.domain;
 
 import static com.sunny.backend.common.CommonErrorCode.*;
-
 import com.sunny.backend.common.CommonCustomException;
 import com.sunny.backend.consumption.dto.request.ConsumptionRequest;
-
 import com.sunny.backend.user.domain.Users;
-
 import javax.validation.constraints.PastOrPresent;
 import javax.validation.constraints.PositiveOrZero;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
-
 import java.time.LocalDate;
 
 @Entity
@@ -55,7 +49,6 @@ public class Consumption {
         this.name = consumptionRequest.getName();
         this.money = consumptionRequest.getMoney();
         this.dateField = consumptionRequest.getDateField();
-
     }
 
     public static void validateConsumptionByUser(Long userId, Long consumptionUserId) {

--- a/src/main/java/com/sunny/backend/consumption/domain/SpendType.java
+++ b/src/main/java/com/sunny/backend/consumption/domain/SpendType.java
@@ -11,18 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum SpendType {
   FOOD("식생활"), SHELTER("주거"), CLOTHING("의류"), OTHERS("기타");
-
   private final String value;
-
   SpendType(String value) {
     this.value = value;
   }
-
   @JsonValue
   public String getValue() {
     return value;
   }
-
   @JsonCreator
   public static SpendType fromValue(String value) {
     for (SpendType type : SpendType.values()) {

--- a/src/main/java/com/sunny/backend/consumption/dto/request/ConsumptionRequest.java
+++ b/src/main/java/com/sunny/backend/consumption/dto/request/ConsumptionRequest.java
@@ -18,18 +18,14 @@ import lombok.Setter;
 @Setter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ConsumptionRequest {
-
     @NotBlank(message = "지출 이름은 필수 입력값입니다.")
     @Size(max = 30, message = "최대 글자 수는 30글자입니다.")
     private String name;
-
     @NotNull(message = "올바른 카테고리 값을 입력해야합니다.")
     private SpendType category;
-
     @PositiveOrZero
     @NotNull(message = "지출 금액은 필수 입력값입니다.")
     private Long money;
-
     @NotNull(message = "지출 날짜는 필수 입력값입니다.")
     @JsonFormat(pattern = "yyyy.MM.dd")
     private LocalDate dateField;

--- a/src/main/java/com/sunny/backend/consumption/dto/request/YearMonthRequest.java
+++ b/src/main/java/com/sunny/backend/consumption/dto/request/YearMonthRequest.java
@@ -1,0 +1,21 @@
+package com.sunny.backend.consumption.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.YearMonth;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@ToString
+@Getter
+@NoArgsConstructor
+public class YearMonthRequest {
+  @NotNull(message = "해당 년/월을 입력해주세요. (ex)'2024.01'")
+  @DateTimeFormat(pattern = "yyyy.MM")
+  @JsonFormat(shape = Shape.STRING,pattern = "yyyy.MM",timezone ="Asia/Seoul" )
+  private YearMonth yearMonth;
+}

--- a/src/main/java/com/sunny/backend/consumption/repository/ConsumptionCustomRepository.java
+++ b/src/main/java/com/sunny/backend/consumption/repository/ConsumptionCustomRepository.java
@@ -1,5 +1,8 @@
 package com.sunny.backend.consumption.repository;
 
+import com.sunny.backend.consumption.domain.SpendType;
+import com.sunny.backend.consumption.dto.request.YearMonthRequest;
+import com.sunny.backend.consumption.dto.response.ConsumptionResponse;
 import com.sunny.backend.consumption.dto.response.SpendTypeStatisticsResponse;
 
 import java.time.LocalDate;
@@ -7,7 +10,9 @@ import java.util.List;
 
 public interface ConsumptionCustomRepository {
 
-    List<SpendTypeStatisticsResponse> getSpendTypeStatistics(Long userId);
+    List<SpendTypeStatisticsResponse> getSpendTypeStatistics(Long userId, YearMonthRequest yearMonthRequest);
+    List<ConsumptionResponse.DetailConsumptionResponse> getConsumptionByCategory(Long userId,
+        SpendType spendType,YearMonthRequest yearMonthRequest);
 
     Long getComsumptionMoney(Long id, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/sunny/backend/consumption/service/ConsumptionService.java
+++ b/src/main/java/com/sunny/backend/consumption/service/ConsumptionService.java
@@ -1,10 +1,9 @@
 package com.sunny.backend.consumption.service;
 
-
-
 import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.common.response.ResponseService;
 import com.sunny.backend.consumption.dto.request.ConsumptionRequest;
+import com.sunny.backend.consumption.dto.request.YearMonthRequest;
 import com.sunny.backend.consumption.dto.response.ConsumptionResponse;
 import com.sunny.backend.consumption.dto.response.SpendTypeStatisticsResponse;
 import com.sunny.backend.consumption.domain.Consumption;
@@ -18,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -26,7 +24,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class ConsumptionService {
-
     private final ConsumptionRepository consumptionRepository;
     private final ResponseService responseService;
 
@@ -41,7 +38,6 @@ public class ConsumptionService {
             .dateField(consumptionRequest.getDateField())
             .users(user)
             .build();
-
         consumptionRepository.save(consumption);
         if (user.getConsumptionList() == null) {
             user.addConsumption(consumption);
@@ -76,24 +72,24 @@ public class ConsumptionService {
 
     @Transactional
     public ResponseEntity<CommonResponse.ListResponse<SpendTypeStatisticsResponse>> getSpendTypeStatistics(
-        CustomUserPrincipal customUserPrincipal) {
+        CustomUserPrincipal customUserPrincipal, YearMonthRequest yearMonthRequest) {
         Users user = customUserPrincipal.getUsers();
         List<SpendTypeStatisticsResponse> statistics = consumptionRepository.getSpendTypeStatistics(
-            user.getId());
+            user.getId(),yearMonthRequest);
         return responseService.getListResponse(HttpStatus.OK.value(),
             statistics, "지출 통계 내역을 불러왔습니다.");
     }
 
     @Transactional
     public ResponseEntity<CommonResponse.ListResponse<ConsumptionResponse.DetailConsumptionResponse>>
-    getDetailConsumption(CustomUserPrincipal customUserPrincipal, LocalDate datefield) {
+    getDetailConsumption(CustomUserPrincipal customUserPrincipal, LocalDate dateField) {
         List<Consumption> detailConsumption =
             consumptionRepository.findByUsersIdAndDateField(customUserPrincipal.getUsers().getId(),
-                datefield);
+                dateField);
         List<ConsumptionResponse.DetailConsumptionResponse> detailConsumptions =
             ConsumptionResponse.DetailConsumptionResponse.listFrom(detailConsumption);
         return responseService.getListResponse(HttpStatus.OK.value(),
-            detailConsumptions, datefield + "에 맞는 지출 내역을 불러왔습니다.");
+            detailConsumptions, dateField + "에 맞는 지출 내역을 불러왔습니다.");
     }
 
     @Transactional
@@ -110,12 +106,9 @@ public class ConsumptionService {
 
     @Transactional
     public ResponseEntity<CommonResponse.ListResponse<ConsumptionResponse.DetailConsumptionResponse>>
-    getConsumptionByCategory(CustomUserPrincipal customUserPrincipal, SpendType spendType) {
-        List<Consumption> detailConsumption =
-            consumptionRepository.findByUsersIdAndCategory(customUserPrincipal.getUsers().getId(),
-                spendType);
+    getConsumptionByCategory(CustomUserPrincipal customUserPrincipal, SpendType spendType,YearMonthRequest yearMonthRequest) {
         List<ConsumptionResponse.DetailConsumptionResponse> detailConsumptions =
-            ConsumptionResponse.DetailConsumptionResponse.listFrom(detailConsumption);
+            consumptionRepository.getConsumptionByCategory(customUserPrincipal.getUsers().getId(),spendType,yearMonthRequest);
         return responseService.getListResponse(HttpStatus.OK.value(),
             detailConsumptions, spendType + "에 맞는 지출 내역을 불러왔습니다.");
     }

--- a/src/main/java/com/sunny/backend/save/controller/SaveController.java
+++ b/src/main/java/com/sunny/backend/save/controller/SaveController.java
@@ -8,14 +8,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.common.config.AuthUser;
 import com.sunny.backend.save.dto.request.SaveRequest;
 import com.sunny.backend.save.dto.response.SaveResponse;
 import com.sunny.backend.auth.jwt.CustomUserPrincipal;
 import com.sunny.backend.save.service.SaveService;
-
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sunny/backend/save/domain/Save.java
+++ b/src/main/java/com/sunny/backend/save/domain/Save.java
@@ -35,7 +35,6 @@ public class Save {
     @Column
     @FutureOrPresent
     private LocalDate startDate;
-
     @Column
     @FutureOrPresent
     private LocalDate endDate;
@@ -58,8 +57,6 @@ public class Save {
         double percentage = userMoney != null ?
             100.0 - (((double) userMoney / (double) save.getCost()) * 100.0) : 100.0;
         BigDecimal roundedPercentage = new BigDecimal(percentage).setScale(1, RoundingMode.HALF_UP);
-
-
         return roundedPercentage.doubleValue();
     }
 }

--- a/src/main/java/com/sunny/backend/save/dto/request/SaveRequest.java
+++ b/src/main/java/com/sunny/backend/save/dto/request/SaveRequest.java
@@ -16,13 +16,11 @@ public class SaveRequest {
 
     @NotNull(message = "지출 금액은 필수 입력값입니다.")
     private Long cost;
-
     @JsonFormat(pattern = "yyyy.MM.dd")
     @NotNull(message = "시작 날짜는 필수 입력값입니다.")
     private LocalDate startDate;
     @JsonFormat(pattern = "yyyy.MM.dd")
     @NotNull(message = "종료 날짜는 필수 입력값입니다.")
-
     private LocalDate endDate;
 }
 

--- a/src/main/java/com/sunny/backend/save/dto/response/SaveResponse.java
+++ b/src/main/java/com/sunny/backend/save/dto/response/SaveResponse.java
@@ -5,7 +5,6 @@ import com.sunny.backend.save.domain.Save;
 import java.time.LocalDate;
 
 public record SaveResponse(
-
     Long id,
     Long cost,
     @JsonFormat(pattern = "yyyy.MM.dd")
@@ -13,7 +12,6 @@ public record SaveResponse(
     @JsonFormat(pattern = "yyyy.MM.dd")
     LocalDate endDate
 ) {
-
     public static SaveResponse from(Save save) {
         return new SaveResponse(
             save.getId(),
@@ -22,14 +20,11 @@ public record SaveResponse(
             save.getEndDate()
         );
     }
-
     public record DetailSaveResponse(
-
         long date,
         double savePercentage
 
     ) {
-
         public static DetailSaveResponse of(long date, double savePercentage) {
             return new DetailSaveResponse(
                 date,

--- a/src/main/java/com/sunny/backend/save/repository/SaveRepository.java
+++ b/src/main/java/com/sunny/backend/save/repository/SaveRepository.java
@@ -8,12 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SaveRepository extends JpaRepository<Save, Long> {
 
   Save findByUsers_Id(Long userId);
-
   List<Save> findByEndDate(LocalDate localDate);
-
   default Save getById(Long id) {
     return findById(id)
         .orElseThrow(() -> new IllegalArgumentException("절약 목표가 존재하지 않습니다."));
   }
-
 }


### PR DESCRIPTION
## PR 타이틀
[feat] 지출 통계 API 수정
### PR 생성 날짜
* 2024-01-21

### PR 내용
1. YYYY-MM월에 해당하는 데이터로 응답해야 됨
    - 해결 완료 ⭐️
    - 지출 통계 조회할 때  YYYY-MM월에 해당하는 통계 내역을 보여줘야됨
    - **지출 통계 조회 API 수정됨**
        - API는 동일 `43.201.176.22:8080/consumption/spendTypeStatistics`
        - Requestbody 추가
        - yearMonth에[YYYY.MM 형식으로 보내줘야됨
       
![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/3a0d5d8d-25b9-4502-80b8-25b460f84e6f)

2. 데이터가 없을 경우 Null이 아니라 0으로 response 주도록 수정
    - 해결 완료 ⭐️
![image](https://github.com/SUNNY-PJ/Backend/assets/78583768/61f197dc-67c5-48a5-9b89-3deca5026a1f)


3. 카테고리 별 조회
    1. FOOD  -  식생활 
    2. SHELTER - 주거 
    3. CLOTHING - 의류 
    4. OTHERS - 기타 
    → params로 보내는 건 영어로!


4. 카테고리별로 클릭했을 때도 해당 년월에 있는 값으로 response 주도록 수정
    - 해결 완료 ⭐️
    - **카테고리 조회 API 수정됨** 
    - API는 동일 `43.201.176.22:8080/consumption/category?spendType=OTHERS`
    - Requestbody 추가
    - yearMonth에 YYYY.MM 형식으로 보내줘야됨