### PR TITLE
[update] save API 추가 & 수정

### DIFF
--- a/src/main/java/com/sunny/backend/comment/service/CommentService.java
+++ b/src/main/java/com/sunny/backend/comment/service/CommentService.java
@@ -143,8 +143,8 @@ public class CommentService {
 		comment.setAuthor(isAuthor);
 		comment.changeIsDeleted(false);
 		commentRepository.save(comment);
-
 		user.addComment(comment);
+		System.out.println(user.getCommentList().size());
 		if(!community.getUsers().getId().equals(customUserPrincipal.getUsers().getId())){
 			if(commentRequestDTO.getParentId() == null) {
 				sendNotifications(customUserPrincipal, comment, community);

--- a/src/main/java/com/sunny/backend/community/service/CommunityService.java
+++ b/src/main/java/com/sunny/backend/community/service/CommunityService.java
@@ -58,15 +58,12 @@ public class CommunityService {
 		Users user = customUserPrincipal.getUsers();
 		Community community = communityRepository.getById(communityId);
 		String viewCount = redisUtil.getData(String.valueOf(user.getId()));
-		System.out.println("viewcount 호출="+viewCount);
 		if (StringUtils.isBlank(viewCount)) {
 			redisUtil.setValuesWithTimeout(String.valueOf(user.getId()), communityId + "_",
 					calculateTimeUntilMidnight());
-			System.out.println(redisUtil.getData(String.valueOf(user.getId())));
 			community.increaseView();
 		} else {
 			List<String> redisBoardList = Arrays.asList(viewCount.split("_"));
-			System.out.println(redisBoardList);
 			boolean isViewed = redisBoardList.contains(String.valueOf(communityId));
 			if (!isViewed) {
 				viewCount += communityId + "_";
@@ -90,7 +87,6 @@ public class CommunityService {
 	public static long calculateTimeUntilMidnight() {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime midnight = now.truncatedTo(ChronoUnit.DAYS).plusDays(1);
-		System.out.println("남은 일수 계산"+ChronoUnit.SECONDS.between(now, midnight));
 		return ChronoUnit.SECONDS.between(now, midnight);
 	}
 
@@ -197,7 +193,6 @@ public class CommunityService {
 			s3Util.deleteFile(existingFile.getFileUrl());
 		}
 		photoRepository.deleteByCommunityId(communityId);
-
 		communityRepository.deleteById(communityId);
 		return responseService.getGeneralResponse(HttpStatus.OK.value(), "게시글을 삭제했습니다.");
 	}

--- a/src/main/java/com/sunny/backend/save/controller/SaveController.java
+++ b/src/main/java/com/sunny/backend/save/controller/SaveController.java
@@ -46,14 +46,14 @@ public class SaveController {
 
 	@ApiOperation(tags = "6. Save", value = "절약 목표 조회")
 	@GetMapping("")
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse.DetailSaveResponse>> getSaveGaol(
+	public ResponseEntity<CommonResponse.ListResponse<SaveResponse.DetailSaveResponse>> getSaveGaol(
 		@AuthUser CustomUserPrincipal customUserPrincipal) {
 		return saveService.getSaveGoal(customUserPrincipal);
 	}
 
 	@ApiOperation(tags = "6. Save", value = "절약 목표 세부 조회")
 	@GetMapping("/detail")
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> getDetailSaveGaol(
+	public ResponseEntity<CommonResponse.ListResponse<SaveResponse>> getDetailSaveGaol(
 			@AuthUser CustomUserPrincipal customUserPrincipal) {
 		return saveService.getDetailSaveGoal(customUserPrincipal);
 	}

--- a/src/main/java/com/sunny/backend/save/domain/Save.java
+++ b/src/main/java/com/sunny/backend/save/domain/Save.java
@@ -32,15 +32,6 @@ public class Save {
     @Column
     @PositiveOrZero
     private Long cost;
-
-    @ColumnDefault("FALSE")
-    @Column(nullable = false)
-    private Boolean success;
-
-    @ColumnDefault("FALSE")
-    @Column(nullable = false)
-    private Boolean expire;
-
     @Column
     @FutureOrPresent
     private LocalDate startDate;
@@ -57,11 +48,6 @@ public class Save {
         this.endDate = saveRequest.getEndDate();
     }
 
-    public void updateSuccessAndExpire(boolean success,boolean expire ) {
-        this.success = success;
-        this.expire = expire;
-    }
-
     public long calculateRemainingDays(Save save) {
         LocalDate currentDate = LocalDate.now();
         return ChronoUnit.DAYS.between(currentDate, save.getEndDate());
@@ -72,5 +58,8 @@ public class Save {
             100.0 - (((double) userMoney / (double) save.getCost()) * 100.0) : 100.0;
         BigDecimal roundedPercentage = new BigDecimal(percentage).setScale(1, RoundingMode.HALF_UP);
         return roundedPercentage.doubleValue();
+    }
+    public boolean checkExpired(LocalDate expirationDate) {
+        return expirationDate != null && LocalDate.now().isAfter(expirationDate);
     }
 }

--- a/src/main/java/com/sunny/backend/save/dto/response/SaveResponse.java
+++ b/src/main/java/com/sunny/backend/save/dto/response/SaveResponse.java
@@ -14,27 +14,28 @@ public record SaveResponse(
     @JsonFormat(pattern = "yyyy.MM.dd")
     LocalDate endDate
 ) {
-    public static SaveResponse from(Save save) {
+    public static SaveResponse from(Save save,boolean success) {
         return new SaveResponse(
             save.getId(),
             save.getCost(),
-            save.getExpire(),
-            save.getSuccess(),
+            save.checkExpired(save.getEndDate()),
+            success,
             save.getStartDate(),
             save.getEndDate()
         );
     }
     public record DetailSaveResponse(
         long date,
-        double savePercentage
+        double savePercentage,
+        Long cost
 
     ) {
-        public static DetailSaveResponse of(long date, double savePercentage) {
+        public static DetailSaveResponse of(long date, double savePercentage,long cost) {
             return new DetailSaveResponse(
                 date,
-                savePercentage
+                savePercentage,
+                cost
             );
         }
     }
-
 }

--- a/src/main/java/com/sunny/backend/save/repository/SaveRepository.java
+++ b/src/main/java/com/sunny/backend/save/repository/SaveRepository.java
@@ -10,8 +10,7 @@ import com.sunny.backend.save.domain.Save;
 
 public interface SaveRepository extends JpaRepository<Save, Long> {
 	Optional<Save> findByUsers_Id(Long userId);
-
-	List<Save> findByEndDate(LocalDate localDate);
+	List<Save> findAllByUsers_Id(Long userId);
 
 	default Save getById(Long id) {
 		return findById(id)

--- a/src/main/java/com/sunny/backend/save/service/SaveService.java
+++ b/src/main/java/com/sunny/backend/save/service/SaveService.java
@@ -1,16 +1,11 @@
 package com.sunny.backend.save.service;
 
-import static com.sunny.backend.save.exception.SaveErrorCode.*;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.sunny.backend.auth.jwt.CustomUserPrincipal;
-import com.sunny.backend.common.exception.CustomException;
 import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.common.response.ResponseService;
 import com.sunny.backend.consumption.repository.ConsumptionRepository;
@@ -26,97 +21,78 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class SaveService {
+
 	private final SaveRepository saveRepository;
 	private final ResponseService responseService;
 	private final ConsumptionRepository consumptionRepository;
 
+	@Transactional
 	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> createSaveGoal(
-		CustomUserPrincipal customUserPrincipal, SaveRequest saveRequest) {
+			CustomUserPrincipal customUserPrincipal, SaveRequest saveRequest) {
 		Users user = customUserPrincipal.getUsers();
-		Save save = Save.builder()
-			.cost(saveRequest.getCost())
-				.success(false)
-				.expire(false)
-			.startDate(saveRequest.getStartDate())
-			.endDate(saveRequest.getEndDate())
-			.users(user)
-			.build();
-		saveRepository.save(save);
-		user.addSave(save);
-
-		return responseService.getSingleResponse(HttpStatus.OK.value(), SaveResponse.from(save), "절약 목표를 등록했습니다.");
+		List<Save> saves = saveRepository.findAllByUsers_Id(user.getId());
+		boolean allSavesExpired = saves.stream().allMatch(save -> save.checkExpired(save.getEndDate()));
+		if (allSavesExpired) {
+			Save save = Save.builder()
+					.cost(saveRequest.getCost())
+					.startDate(saveRequest.getStartDate())
+					.endDate(saveRequest.getEndDate())
+					.users(user)
+					.build();
+			saveRepository.save(save);
+			user.addSave(save);
+			return responseService.getSingleResponse(HttpStatus.OK.value(), SaveResponse.from(save,true),
+					"절약 목표를 등록했습니다.");
+		} else {
+			if (!saves.isEmpty()) {
+				Save lastSave = saves.get(saves.size() - 1);
+				SaveResponse saveResponse = SaveResponse.from(lastSave,checkSuccessed(user,lastSave));
+				return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse, "이미 등록된 절약 목표가 존재합니다.");
+			} else {
+				return responseService.getSingleResponse(HttpStatus.OK.value(), null, "등록된 절약 목표를 찾을 수 없습니다.");
+			}
+		}
 	}
 
 	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> updateSaveGoal(
 		CustomUserPrincipal customUserPrincipal, SaveRequest saveRequest) {
 		Users user = customUserPrincipal.getUsers();
-		Save save = saveRepository.findByUsers_Id(user.getId())
-			.orElseThrow(() -> new CustomException(SAVE_NOT_FOUND));
-		save.updateSave(saveRequest);
-		return responseService.getSingleResponse(HttpStatus.OK.value(), SaveResponse.from(save), "절약 목표를 수정했습니다.");
+		List<Save> saves = saveRepository.findAllByUsers_Id(user.getId());
+		Save lastSave = saves.get(saves.size() - 1);
+		lastSave.updateSave(saveRequest);
+		boolean success=checkSuccessed(user,lastSave);
+		return responseService.getSingleResponse(HttpStatus.OK.value(), SaveResponse.from(lastSave,success), "절약 목표를 수정했습니다.");
 	}
 
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse.DetailSaveResponse>> getSaveGoal(
-		CustomUserPrincipal customUserPrincipal) {
-		Users user = customUserPrincipal.getUsers();
-		Save save = saveRepository.findByUsers_Id(user.getId())
-			.orElseThrow(() -> new CustomException(SAVE_NOT_FOUND));
-
-		long remainingDays = save.calculateRemainingDays(save);
-		Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(),
-			save.getEndDate());
-		double percentageUsed = save.calculateSavePercentage(userMoney, save);
-		SaveResponse.DetailSaveResponse saveResponse = SaveResponse.DetailSaveResponse.of(remainingDays,
-			percentageUsed);
-		return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse,
-			"절약 목표를 성공적으로 조회했습니다.");
-	}
-
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> getDetailSaveGoal(
+	@Transactional
+	public ResponseEntity<CommonResponse.ListResponse<SaveResponse.DetailSaveResponse>> getSaveGoal(
 			CustomUserPrincipal customUserPrincipal) {
 		Users user = customUserPrincipal.getUsers();
-		Save save = saveRepository.findByUsers_Id(user.getId())
-				.orElseThrow(() -> new CustomException(SAVE_NOT_FOUND));
-		boolean expire=true;
-		boolean success=false;
-		long remainingDays = save.calculateRemainingDays(save);
-		Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(),
-				save.getEndDate());
-		double percentageUsed = save.calculateSavePercentage(userMoney, save);
-		if(remainingDays>0) {
-			System.out.println("왜 호출됨");
-			expire=false;
-		}
-		else if(percentageUsed>0){
-			success=true;
-		}
-		save.updateSuccessAndExpire(expire,success);
-		SaveResponse saveResponse=SaveResponse.from(save);
-		return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse,
+		List<Save> saves = saveRepository.findAllByUsers_Id(user.getId());
+		List<SaveResponse.DetailSaveResponse> saveResponses = saves.stream().map(save -> {
+			long remainingDays = save.calculateRemainingDays(save);
+			Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(), save.getEndDate());
+			double percentageUsed = save.calculateSavePercentage(userMoney,save);
+			return SaveResponse.DetailSaveResponse.of(remainingDays, percentageUsed,save.getCost());
+		}).toList();
+		return responseService.getListResponse(HttpStatus.OK.value(), saveResponses,
+				"절약 목표를 성공적으로 조회했습니다.");
+	}
+	public ResponseEntity<CommonResponse.ListResponse<SaveResponse>> getDetailSaveGoal(
+			CustomUserPrincipal customUserPrincipal) {
+		Users user = customUserPrincipal.getUsers();
+		List<Save> saves = saveRepository.findAllByUsers_Id(user.getId());
+		List<SaveResponse> saveResponses = saves.stream().map(save -> {
+			return SaveResponse.from(save,checkSuccessed(user,save));
+		}).toList();
+		return responseService.getListResponse(HttpStatus.OK.value(), saveResponses,
 				"절약 목표 성공적으로 조회했습니다.");
 	}
 
-	public ResponseEntity<CommonResponse.SingleResponse<SaveResponse>> getEndSaveGoal(
-			CustomUserPrincipal customUserPrincipal) {
-		Users user = customUserPrincipal.getUsers();
-		Save save = saveRepository.findByUsers_Id(user.getId())
-				.orElseThrow(() -> new CustomException(SAVE_NOT_FOUND));
-		boolean expire=false;
-		boolean success=false;
-		long remainingDays = save.calculateRemainingDays(save);
-		Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(),
-				save.getEndDate());
-		double percentageUsed = save.calculateSavePercentage(userMoney, save);
-		if(remainingDays<0 && percentageUsed<0) {
-			expire=true;
-		}
-		if(percentageUsed>0){
-			success=true;
-		}
-		save.updateSuccessAndExpire(expire,success);
-		SaveResponse saveResponse=SaveResponse.from(save);
-		return responseService.getSingleResponse(HttpStatus.OK.value(), saveResponse,
-				"절약 목표 성공적으로 조회했습니다.");
+	public boolean checkSuccessed(Users user,Save save) {
+		Long userMoney = consumptionRepository.getComsumptionMoney(user.getId(), save.getStartDate(), save.getEndDate());
+		double percentageUsed = save.calculateSavePercentage(userMoney,save);
+		return percentageUsed >= 0;
 	}
 
 }


### PR DESCRIPTION
## PR 타이틀
[update] save API 추가 & 수정
### PR 생성 날짜
* 2024-02-21

### PR 내용
- 남은 일수랑, 퍼센트 반환하는 response에 cost 추가
- 절약 목표 처음 등록할 때 response 
 - expire가 false , 즉 만료되지 않은 상태에서 새로운 절약 목표를 등록하려고 할 때 response
    - 프론트에서도 못하도록 처리하겠지만 혹시 모르니 서버에서도 한 번 더 검사
    - 새로운 절약 목표는 등록되지 않고, 기존에 진행중인 절약 목표를 data값으로 넘김
        - 아니면 null값으로 넘길지 프론트와 논의
    - msg도 “이미 등록된 절약 목표가 존재합니다.” 로 변경
- 절약 목표 조회 api 추가 (/save/detail)