### PR TITLE
[fix] 알림 token 중복 방지 추가

### DIFF
--- a/src/main/java/com/sunny/backend/comment/service/CommentService.java
+++ b/src/main/java/com/sunny/backend/comment/service/CommentService.java
@@ -150,7 +150,7 @@ public class CommentService {
 				sendNotifications(customUserPrincipal, comment, community);
 			}
 			else{
-				replySendNotifications(comment.getParent().getUsers(), comment, community);
+				replySendNotifications(customUserPrincipal,comment.getParent().getUsers(), comment, community);
 			}
 		}
 		return responseService.getSingleResponse(HttpStatus.OK.value(),
@@ -170,12 +170,12 @@ public class CommentService {
 			return comment.getContent();
 		}
 	}
-	private void replySendNotifications(Users users,
+	private void replySendNotifications(CustomUserPrincipal customUserPrincipal,Users users,
 			Comment comment, Community community) throws IOException {
 		Long postAuthor=users.getId();
 		List<Notification> notificationList=notificationRepository.findByUsers_Id(users.getId());
 		String body = comment.getContent();
-		String title="[SUNNY] "+users.getNickname();
+		String title="[SUNNY] "+customUserPrincipal.getUsers().getNickname();
 		String bodyTitle="새로운 답글이 달렸어요";
 		CommentNotification commentNotification=CommentNotification.builder()
 				.users(users)
@@ -191,7 +191,7 @@ public class CommentService {
 					bodyTitle,
 					body
 			);
-			notificationService.sendNotificationToFriends(title,notificationPushRequest);
+			notificationService.commentSendNotificationToFriends(title,notificationPushRequest);
 		}
 	}
 	private void sendNotifications(CustomUserPrincipal customUserPrincipal,

--- a/src/main/java/com/sunny/backend/notification/domain/Notification.java
+++ b/src/main/java/com/sunny/backend/notification/domain/Notification.java
@@ -15,7 +15,7 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(unique = true)
     private String DeviceToken;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## PR 타이틀
[fix] 알림 token 중복 방지 추가
### PR 생성 날짜
* 2024-03-03

### PR 내용
- 알림 token 중복 방지 추가
   - 디바이스 토큰이 중복되면 알림이 여러 번 반복적으로 전송되는 것을 방지하기 위함
- 답글 배너 알림 form 수정