### PR TITLE
[update] apple_login 탈퇴 API 업데이트

### DIFF
--- a/src/main/java/com/sunny/backend/auth/dto/AppleAuthClient.java
+++ b/src/main/java/com/sunny/backend/auth/dto/AppleAuthClient.java
@@ -7,6 +7,8 @@ import com.sunny.backend.apple.ApplePublicKeys;
 import com.sunny.backend.apple.AppleRevokeRequest;
 import com.sunny.backend.apple.AppleSocialTokenInfoResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,5 +34,14 @@ public interface AppleAuthClient {
 
     @PostMapping(value = "/revoke",consumes = "application/x-www-form-urlencoded" )
     void revoke(AppleRevokeRequest appleRevokeRequest);
-  }
+
+    @PostMapping(value = "/revoke", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    ResponseEntity<String> revokeToken(@RequestParam("client_id") String clientId,
+        @RequestParam("client_secret") String clientSecret,
+        @RequestParam("token") String token,
+        @RequestParam("token_type_hint") String tokenTypeHint);
+}
+
+
+
 

--- a/src/main/java/com/sunny/backend/comment/service/CommentService.java
+++ b/src/main/java/com/sunny/backend/comment/service/CommentService.java
@@ -49,7 +49,7 @@ public class CommentService {
 	public CommentResponse mapCommentToResponse(Comment comment, Users currentUser) {
 		CommentResponse commentResponse;
 		if (comment.getUsers() != null && comment.getUsers().getId() != null) {
-			// Users object associated with the comment is not null
+
 			boolean isPrivate = comment.getIsPrivated();
 			boolean commentAuthor = currentUser.getId().equals(comment.getUsers().getId());
 			String writer = comment.getUsers().getNickname();
@@ -65,7 +65,7 @@ public class CommentService {
 
 			if (isPrivate && !(currentUser.getId().equals(comment.getUsers().getId()) ||
 					currentUser.getId().equals(comment.getCommunity().getUsers().getId()))) {
-				// Handle private comment
+
 				commentResponse = new CommentResponse(
 						comment.getId(),
 						comment.getUsers().getId(),
@@ -79,7 +79,6 @@ public class CommentService {
 						comment.getIsPrivated()
 				);
 			} else {
-				// Handle regular comment
 				commentResponse = new CommentResponse(
 						comment.getId(),
 						comment.getUsers().getId(),
@@ -94,11 +93,8 @@ public class CommentService {
 				);
 			}
 		} else {
-			// Users object associated with the comment is null
 			commentResponse = leaveCommentToDto(currentUser, comment);
 		}
-
-		// Set children comments recursively
 		commentResponse.setChildren(
 				comment.getChildren().stream()
 						.map(childComment -> mapCommentToResponse(childComment, currentUser))


### PR DESCRIPTION
## PR 타이틀
[update] apple_login 탈퇴 API 업데이트
### PR 생성 날짜
* 2024-03-28

### PR 내용
apple_login 탈퇴 API 업데이트
- connection 누수 발생 이슈로 Okhttp 라이브러리 대신 feign 사용
