### PR TITLE
feat : 친구인 유저 차단 시 친구&경쟁 삭제

### DIFF
--- a/src/main/java/com/sunny/backend/user/controller/UserController.java
+++ b/src/main/java/com/sunny/backend/user/controller/UserController.java
@@ -19,6 +19,7 @@ import com.sunny.backend.common.config.AuthUser;
 import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.user.dto.request.UserBlockRequest;
 import com.sunny.backend.user.dto.response.ProfileResponse;
+import com.sunny.backend.user.dto.response.UserBlockResponse;
 import com.sunny.backend.user.dto.response.UserCommentResponse;
 import com.sunny.backend.user.dto.response.UserCommunityResponse;
 import com.sunny.backend.user.dto.response.UserScrapResponse;
@@ -82,11 +83,11 @@ public class UserController {
 
 	@ApiOperation(tags = "0. User", value = "사용자 차단 목록 가져오기")
 	@GetMapping("block")
-	public ResponseEntity<Void> blockUser(
+	public ResponseEntity<List<UserBlockResponse>> blockUser(
 		@AuthUser CustomUserPrincipal customUserPrincipal
 	) {
-		userService.getBlockUser(customUserPrincipal);
-		return ResponseEntity.noContent().build();
+		List<UserBlockResponse> userBlockResponses = userService.getBlockedUser(customUserPrincipal);
+		return ResponseEntity.ok(userBlockResponses);
 	}
 
 	@ApiOperation(tags = "0. User", value = "사용자 차단")

--- a/src/main/java/com/sunny/backend/user/service/UserDeleteService.java
+++ b/src/main/java/com/sunny/backend/user/service/UserDeleteService.java
@@ -1,0 +1,50 @@
+package com.sunny.backend.user.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.sunny.backend.competition.repository.CompetitionRepository;
+import com.sunny.backend.friends.domain.FriendCompetition;
+import com.sunny.backend.friends.repository.FriendCompetitionRepository;
+import com.sunny.backend.friends.repository.FriendRepository;
+import com.sunny.backend.notification.repository.CompetitionNotificationRepository;
+import com.sunny.backend.notification.repository.FriendsNotificationRepository;
+import com.sunny.backend.user.domain.Users;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+
+	private final FriendRepository friendRepository;
+	private final CompetitionNotificationRepository competitionNotificationRepository;
+	private final FriendCompetitionRepository friendCompetitionRepository;
+	private final CompetitionRepository competitionRepository;
+	private final FriendsNotificationRepository friendsNotificationRepository;
+
+	public void deleteFriendRelationships(List<FriendCompetition> friendCompetitions) {
+		for (FriendCompetition friendCompetition : friendCompetitions) {
+			competitionNotificationRepository.deleteAllByFriendCompetition(friendCompetition);
+			friendCompetitionRepository.deleteById(friendCompetition.getId());
+		}
+		Set<Long> competitionIds = friendCompetitions.stream()
+			.map(friendCompetition -> friendCompetition.getCompetition().getId())
+			.collect(Collectors.toSet());
+		if (!competitionIds.isEmpty()) {
+			competitionRepository.deleteAllById(competitionIds);
+		}
+	}
+
+	public void deleteFriendRelationshipsByUser(List<FriendCompetition> friendCompetitions, Users users, Users usersFriend) {
+		deleteFriendRelationships(friendCompetitions);
+
+		friendsNotificationRepository.deleteByUsersAndFriend(users, usersFriend);
+		friendsNotificationRepository.deleteByUsersAndFriend(usersFriend, users);
+		friendRepository.deleteByUsersAndUserFriend(users, usersFriend);
+		friendRepository.deleteByUsersAndUserFriend(usersFriend, users);
+	}
+}

--- a/src/main/java/com/sunny/backend/user/service/UserService.java
+++ b/src/main/java/com/sunny/backend/user/service/UserService.java
@@ -4,6 +4,9 @@ import static com.sunny.backend.common.ComnConstant.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +19,15 @@ import com.sunny.backend.comment.repository.CommentRepository;
 import com.sunny.backend.common.response.CommonResponse;
 import com.sunny.backend.common.response.ResponseService;
 import com.sunny.backend.community.repository.CommunityRepository;
+import com.sunny.backend.competition.repository.CompetitionRepository;
+import com.sunny.backend.friends.domain.Friend;
+import com.sunny.backend.friends.domain.FriendCompetition;
+import com.sunny.backend.friends.repository.FriendCompetitionRepository;
 import com.sunny.backend.friends.repository.FriendRepository;
 import com.sunny.backend.notification.domain.Notification;
 import com.sunny.backend.notification.dto.request.NotificationPushRequest;
+import com.sunny.backend.notification.repository.CompetitionNotificationRepository;
+import com.sunny.backend.notification.repository.FriendsNotificationRepository;
 import com.sunny.backend.notification.repository.NotificationRepository;
 import com.sunny.backend.notification.service.NotificationService;
 import com.sunny.backend.scrap.repository.ScrapRepository;
@@ -50,6 +59,8 @@ public class UserService {
 	private final S3Util s3Util;
 	private final FriendRepository friendRepository;
 	private final UserBlockRepository userBlockRepository;
+	private final UserDeleteService userDeleteService;
+	private final FriendCompetitionRepository friendCompetitionRepository;
 
 	public Users checkUserId(CustomUserPrincipal customUserPrincipal, Long userId) {
 		Long id = customUserPrincipal.getId();
@@ -136,7 +147,7 @@ public class UserService {
 		}
 	}
 
-	public List<UserBlockResponse> getBlockUser(CustomUserPrincipal customUserPrincipal) {
+	public List<UserBlockResponse> getBlockedUser(CustomUserPrincipal customUserPrincipal) {
 		Users users = userRepository.getById(customUserPrincipal.getId());
 
 		return users.getBlockedUsers()
@@ -149,6 +160,14 @@ public class UserService {
 	public void blockUser(CustomUserPrincipal customUserPrincipal, UserBlockRequest userBlockRequest) {
 		Users users = userRepository.getById(customUserPrincipal.getId());
 		Users blockUser = userRepository.getById(userBlockRequest.userId());
+
+		Optional<Friend> optionalFriend = friendRepository.findByUsersAndUserFriend(users, blockUser);
+		if (optionalFriend.isPresent()) {
+			Friend friend = optionalFriend.get();
+			List<FriendCompetition> friendCompetitions = friendCompetitionRepository.getByUserOrUserFriend(users.getId(),
+				friend.getUserFriend().getId());
+			userDeleteService.deleteFriendRelationshipsByUser(friendCompetitions, users, blockUser);
+		}
 
 		UsersBlock usersBlock = UsersBlock.of(users, blockUser);
 		userBlockRepository.save(usersBlock);


### PR DESCRIPTION
### PR 내용
유저를 삭제하면서 친구+경쟁 삭제 하는 메소드가 (회원탈퇴, 친구 삭제, 유저 차단)에서 사용 되기 때문에 재사용하기 위해서 UserDeleteService 라는 클래스를 만들었는데 
예림님이 생각하기에 더 좋은 방법이 있을 것 같나요??