### PR TITLE
hotfix : 조회수 증가 방지 메서드 수정

### DIFF
--- a/src/main/java/com/sunny/backend/community/domain/BoardType.java
+++ b/src/main/java/com/sunny/backend/community/domain/BoardType.java
@@ -5,9 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import lombok.Getter;
 
+/** 게시판 Type
+ * 자유 게시판 (FREE)
+ * 절약 꿀팁 (SAVING_TIPS)
+ * */
+
 @Getter
 public enum BoardType {
-	TIP("절약 꿀팁"), FREE("자유 게시판");
+	SAVING_TIPS("절약 꿀팁"), FREE("자유 게시판");
 	private final String value;
 
 	BoardType(String value) {

--- a/src/main/java/com/sunny/backend/community/domain/Community.java
+++ b/src/main/java/com/sunny/backend/community/domain/Community.java
@@ -18,7 +18,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.annotations.ColumnDefault;
@@ -54,7 +53,6 @@ public class Community {
 	private int viewCnt;
 
 	@Enumerated(EnumType.STRING)
-	@NotNull(message = "올바른 카테고리 값을 입력해야합니다.")
 	private BoardType boardType;
 
 	@Column

--- a/src/main/java/com/sunny/backend/community/domain/SortType.java
+++ b/src/main/java/com/sunny/backend/community/domain/SortType.java
@@ -5,9 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import lombok.Getter;
 
+/** 게시판 정렬 type
+ * 조회순 (VIEW_COUNT)
+ * 최신순 (LATEST)
+ * */
+
 @Getter
 public enum SortType {
-	VIEW("조회순"), LATEST("최신순");
+	VIEW_COUNT("조회순"), LATEST("최신순");
 	private final String value;
 
 	SortType(String value) {

--- a/src/main/java/com/sunny/backend/community/dto/request/CommunityRequest.java
+++ b/src/main/java/com/sunny/backend/community/dto/request/CommunityRequest.java
@@ -3,20 +3,18 @@ package com.sunny.backend.community.dto.request;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.sunny.backend.community.domain.BoardType;
 
 import lombok.Getter;
 
 @Getter
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class CommunityRequest {
 	@NotBlank(message = "제목은 필수 입력값입니다.")
 	private String title;
 
 	@NotBlank(message = "내용은 필수 입력값입니다.")
 	private String contents;
+
 	@NotNull(message = "올바른 카테고리 값을 입력해야합니다.")
 	private BoardType type;
 }

--- a/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/com/sunny/backend/community/repository/CommunityRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CommunityRepositoryImpl extends QuerydslRepositorySupport implement
 					.join(users).on(community.users.id.eq(users.id))
 					.join(usersBlock).on(users.id.eq(usersBlock.users.id))
 					.where(usersBlock.blockedUser.id.eq(user.getId()))))
-			.orderBy(sortType == SortType.VIEW ? community.viewCnt.desc() : community.createdAt.desc())
+			.orderBy(sortType == SortType.VIEW_COUNT ? community.viewCnt.desc() : community.createdAt.desc())
 			.limit(pageSize)
 			.fetch();
 
@@ -68,17 +68,12 @@ public class CommunityRepositoryImpl extends QuerydslRepositorySupport implement
 	}
 
 	private BooleanExpression eqBoardType(BoardType boardType) {
-		if (boardType == BoardType.TIP) {
-			return community.boardType.eq(BoardType.TIP);
+		if (boardType == BoardType.SAVING_TIPS) {
+			return community.boardType.eq(BoardType.SAVING_TIPS);
 		} else if (boardType == BoardType.FREE) {
 			return community.boardType.eq(BoardType.FREE);
 		}
 		return null;
 	}
 
-	public List<Long> extractUserIds(List<CommunityPageResponse> communityResponses) {
-		return communityResponses.stream()
-			.map(CommunityPageResponse::userId)
-			.toList();
-	}
 }

--- a/src/main/java/com/sunny/backend/report/controller/ReportController.java
+++ b/src/main/java/com/sunny/backend/report/controller/ReportController.java
@@ -1,0 +1,27 @@
+package com.sunny.backend.report.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sunny.backend.report.dto.response.AllReportResponse;
+import com.sunny.backend.report.service.ReportService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "10. Back-Offcie-Report", description = "Back-Offcie-Report API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report/all")
+public class ReportController {
+	private final ReportService reportService;
+
+	@GetMapping("/community")
+	public List<AllReportResponse> ReportAllByCommunity() {
+		return reportService.ReportResult();
+	}
+
+}

--- a/src/main/java/com/sunny/backend/report/domain/CommentReport.java
+++ b/src/main/java/com/sunny/backend/report/domain/CommentReport.java
@@ -2,7 +2,6 @@ package com.sunny.backend.report.domain;
 
 import static com.sunny.backend.report.exception.ReportErrorCode.*;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -54,16 +53,16 @@ public class CommentReport extends BaseTime {
 	}
 
 	public static CommentReport of(Users users, Comment comment, String reason) {
-		return new CommentReport(users, comment, reason, ReportStatus.WAIT);
+		return new CommentReport(users, comment, reason, ReportStatus.RECEIVING);
 	}
 
 	public void validateWaitStatus() {
-		if (status != ReportStatus.WAIT) {
+		if (status != ReportStatus.RECEIVING) {
 			throw new CustomException(ALREADY_PROCESS);
 		}
 	}
 
 	public void approveStatus() {
-		status = ReportStatus.APPROVE;
+		status = ReportStatus.APPROVED;
 	}
 }

--- a/src/main/java/com/sunny/backend/report/domain/CommunityReport.java
+++ b/src/main/java/com/sunny/backend/report/domain/CommunityReport.java
@@ -53,16 +53,16 @@ public class CommunityReport extends BaseTime {
 	}
 
 	public static CommunityReport of(Users users, Community community, String reason) {
-		return new CommunityReport(users, community, reason, ReportStatus.WAIT);
+		return new CommunityReport(users, community, reason, ReportStatus.RECEIVING);
 	}
 
 	public void validateWaitStatus() {
-		if (status != ReportStatus.WAIT) {
+		if (status != ReportStatus.RECEIVING) {
 			throw new CustomException(ALREADY_PROCESS);
 		}
 	}
 
 	public void approveStatus() {
-		status = ReportStatus.APPROVE;
+		status = ReportStatus.APPROVED;
 	}
 }

--- a/src/main/java/com/sunny/backend/report/domain/ReportStatus.java
+++ b/src/main/java/com/sunny/backend/report/domain/ReportStatus.java
@@ -3,8 +3,17 @@ package com.sunny.backend.report.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/** 신고 상태
+ * 신고 검토중 <- 접수 or 검토는 같은 의미라고 생각해서 상태 하나 제외해도 될 듯
+ * 신고 접수중
+ * 신고 거절
+ * 신고 승인
+ * */
 @Getter
 @RequiredArgsConstructor
 public enum ReportStatus {
-	WAIT, APPROVE;
+	PENDING, //TODO 삭제될 수 있음
+	RECEIVING,
+	REFUSED,
+	APPROVED
 }

--- a/src/main/java/com/sunny/backend/report/domain/ReportType.java
+++ b/src/main/java/com/sunny/backend/report/domain/ReportType.java
@@ -6,5 +6,5 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ReportType {
-	COMMUNITY, COMMENT;
+	COMMUNITY, COMMENT
 }

--- a/src/main/java/com/sunny/backend/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/sunny/backend/report/dto/request/ReportCreateRequest.java
@@ -1,4 +1,4 @@
-package com.sunny.backend.report.dto;
+package com.sunny.backend.report.dto.request;
 
 import com.sunny.backend.report.domain.ReportType;
 

--- a/src/main/java/com/sunny/backend/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/sunny/backend/report/dto/request/ReportRequest.java
@@ -1,4 +1,4 @@
-package com.sunny.backend.report.dto;
+package com.sunny.backend.report.dto.request;
 
 import com.sunny.backend.report.domain.ReportType;
 

--- a/src/main/java/com/sunny/backend/report/dto/response/AllReportResponse.java
+++ b/src/main/java/com/sunny/backend/report/dto/response/AllReportResponse.java
@@ -1,0 +1,28 @@
+package com.sunny.backend.report.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sunny.backend.report.domain.CommunityReport;
+import com.sunny.backend.report.domain.ReportStatus;
+
+public record AllReportResponse(
+	Long reportId,
+	Long userId,
+	Long reportUserId,
+	String reportReason,
+	LocalDateTime reportDate, //TODO 시간도 필요한지?
+	ReportStatus reportStatus,
+	Long communityId // TODO community or comment 일텐데 이거 id 구분 잘해야될 듯
+) {
+	public static AllReportResponse fromCommunityReport(CommunityReport communityReport) {
+		return new AllReportResponse(
+			communityReport.getId(),
+			communityReport.getUsers().getId(), //신고한 사람
+			communityReport.getCommunity().getUsers().getId(), //신고 당한사람
+			communityReport.getReason(),
+			communityReport.getCreatedDate(),
+			communityReport.getStatus(),
+			communityReport.getCommunity().getId()
+		);
+	}
+}

--- a/src/main/java/com/sunny/backend/report/service/CommentReportService.java
+++ b/src/main/java/com/sunny/backend/report/service/CommentReportService.java
@@ -10,7 +10,7 @@ import com.sunny.backend.comment.repository.CommentRepository;
 import com.sunny.backend.notification.domain.NotifiacationSubType;
 import com.sunny.backend.report.domain.CommentReport;
 import com.sunny.backend.report.domain.ReportType;
-import com.sunny.backend.report.dto.ReportCreateRequest;
+import com.sunny.backend.report.dto.request.ReportCreateRequest;
 import com.sunny.backend.report.repository.CommentReportRepository;
 import com.sunny.backend.user.domain.Users;
 import com.sunny.backend.user.dto.response.ReportResponse;

--- a/src/main/java/com/sunny/backend/report/service/CommunityReportService.java
+++ b/src/main/java/com/sunny/backend/report/service/CommunityReportService.java
@@ -11,7 +11,7 @@ import com.sunny.backend.notification.domain.NotifiacationSubType;
 import com.sunny.backend.notification.service.FriendNotiService;
 import com.sunny.backend.report.domain.CommunityReport;
 import com.sunny.backend.report.domain.ReportType;
-import com.sunny.backend.report.dto.ReportCreateRequest;
+import com.sunny.backend.report.dto.request.ReportCreateRequest;
 import com.sunny.backend.report.repository.CommunityReportRepository;
 import com.sunny.backend.user.domain.Users;
 import com.sunny.backend.user.dto.response.ReportResponse;

--- a/src/main/java/com/sunny/backend/report/service/ReportService.java
+++ b/src/main/java/com/sunny/backend/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.sunny.backend.report.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.transaction.Transactional;
@@ -12,8 +13,12 @@ import com.sunny.backend.notification.domain.Notification;
 import com.sunny.backend.notification.dto.request.NotificationPushRequest;
 import com.sunny.backend.notification.repository.NotificationRepository;
 import com.sunny.backend.notification.service.NotificationService;
+import com.sunny.backend.report.domain.CommunityReport;
 import com.sunny.backend.report.domain.ReportType;
-import com.sunny.backend.report.dto.ReportCreateRequest;
+import com.sunny.backend.report.dto.request.ReportCreateRequest;
+import com.sunny.backend.report.dto.response.AllReportResponse;
+import com.sunny.backend.report.repository.CommentReportRepository;
+import com.sunny.backend.report.repository.CommunityReportRepository;
 import com.sunny.backend.user.domain.Users;
 import com.sunny.backend.user.dto.response.ReportResponse;
 import com.sunny.backend.user.dto.response.UserReportResponse;
@@ -26,6 +31,8 @@ public class ReportService {
 	private final ReportFactory reportFactory;
 	private final NotificationRepository notificationRepository;
 	private final NotificationService notificationService;
+	private final CommentReportRepository commentReportRepository;
+	private final CommunityReportRepository communityReportRepository;
 
 	public List<ReportResponse> getUserReports(ReportType reportType) {
 		ReportStrategy reportStrategy = reportFactory.findReportStrategy(reportType);
@@ -69,6 +76,16 @@ public class ReportService {
 			);
 			notificationService.sendNotificationToFriends(title, notificationPushRequest);
 		}
+	}
+
+	public List<AllReportResponse> ReportResult() {
+		List<CommunityReport> communityReportList = communityReportRepository.findAll();
+
+		List<AllReportResponse> communityReports = new ArrayList<>();
+		for (CommunityReport communityReport : communityReportList) {
+			communityReports.add(AllReportResponse.fromCommunityReport(communityReport));
+		}
+		return communityReports;
 	}
 
 }

--- a/src/main/java/com/sunny/backend/report/service/ReportStrategy.java
+++ b/src/main/java/com/sunny/backend/report/service/ReportStrategy.java
@@ -3,7 +3,7 @@ package com.sunny.backend.report.service;
 import java.util.List;
 
 import com.sunny.backend.report.domain.ReportType;
-import com.sunny.backend.report.dto.ReportCreateRequest;
+import com.sunny.backend.report.dto.request.ReportCreateRequest;
 import com.sunny.backend.user.dto.response.ReportResponse;
 import com.sunny.backend.user.dto.response.UserReportResponse;
 

--- a/src/main/java/com/sunny/backend/user/controller/UserReportController.java
+++ b/src/main/java/com/sunny/backend/user/controller/UserReportController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sunny.backend.auth.jwt.CustomUserPrincipal;
 import com.sunny.backend.common.config.AuthUser;
 import com.sunny.backend.report.domain.ReportType;
-import com.sunny.backend.report.dto.ReportCreateRequest;
+import com.sunny.backend.report.dto.request.ReportCreateRequest;
 import com.sunny.backend.report.service.ReportService;
 import com.sunny.backend.user.dto.response.ReportResponse;
 import com.sunny.backend.user.dto.response.UserReportResponse;

--- a/src/main/java/com/sunny/backend/util/RedisUtil.java
+++ b/src/main/java/com/sunny/backend/util/RedisUtil.java
@@ -8,15 +8,21 @@ import org.springframework.stereotype.Component;
 
 import com.sunny.backend.common.CommonErrorCode;
 import com.sunny.backend.common.exception.CustomException;
+import com.sunny.backend.community.domain.Community;
+import com.sunny.backend.community.repository.CommunityRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RedisUtil {
 	private final RedisTemplate<String, String> redisTemplate;
+	private final CommunityRepository communityRepository;
 
 	public String getData(String key) {
+		log.info(redisTemplate.opsForValue().get(key));
 		return redisTemplate.opsForValue().get(key);
 	}
 
@@ -27,7 +33,13 @@ public class RedisUtil {
 	}
 
 	public void setValuesWithTimeout(String key, String value, long timeout) {
-		redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
+		try {
+			redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
+			log.info("Redis Value 저장 성공!");
+		} catch (Exception e) {
+			log.info("Redis Value 저장 에러!: " + e.getMessage());
+			e.printStackTrace();
+		}
 	}
 
 	public String getRefreshToken(String refreshToken) {
@@ -50,4 +62,23 @@ public class RedisUtil {
 		return valueOperations.get(accessToken);
 	}
 
+	//user가 게시글을 봤는지 체크
+	public boolean hasUserViewedCommunity(Long userId, Long postId) {
+		String userKey = "user:" + userId;
+		return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(userKey, postId.toString()));
+	}
+
+	public void addUserView(Long userId, Long postId) {
+		String userKey = "user:" + userId;
+		redisTemplate.opsForSet().add(userKey, postId.toString());
+		redisTemplate.expire(userKey, 24, TimeUnit.HOURS);
+	}
+
+	public void incrementCommunityViewIfNotViewed(Long userId, Long postId) {
+		Community community = communityRepository.getById(postId);
+		if (!hasUserViewedCommunity(userId, postId)) {
+			addUserView(userId, postId);
+			community.increaseView();
+		}
+	}
 }

--- a/src/main/java/com/sunny/backend/util/RedisUtil.java
+++ b/src/main/java/com/sunny/backend/util/RedisUtil.java
@@ -68,6 +68,7 @@ public class RedisUtil {
 		return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(userKey, postId.toString()));
 	}
 
+	//최초 게시글 조회 시 redis에 key,value,expire 추가
 	public void addUserView(Long userId, Long postId) {
 		String userKey = "user:" + userId;
 		redisTemplate.opsForSet().add(userKey, postId.toString());

--- a/src/main/java/com/sunny/backend/util/RedisUtil.java
+++ b/src/main/java/com/sunny/backend/util/RedisUtil.java
@@ -75,6 +75,7 @@ public class RedisUtil {
 		redisTemplate.expire(userKey, 24, TimeUnit.HOURS);
 	}
 
+	// 사용자가 조회한 게시글인지 아닌지 check
 	public void incrementCommunityViewIfNotViewed(Long userId, Long postId) {
 		Community community = communityRepository.getById(postId);
 		if (!hasUserViewedCommunity(userId, postId)) {

--- a/src/main/java/com/sunny/backend/util/S3Util.java
+++ b/src/main/java/com/sunny/backend/util/S3Util.java
@@ -95,7 +95,6 @@ public class S3Util {
 	// DeleteObject를 통해 S3 파일 삭제
 	public void deleteFile(String fileName) {
 		String objectKey = parseObjectKeyFromUrl(fileName);
-
 		// 삭제
 		DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, objectKey);
 		s3Client.deleteObject(deleteObjectRequest);


### PR DESCRIPTION
## PR 타이틀
#253 이슈 hotfix : 조회수 증가 방지 메서드 수정 
### PR 생성 날짜
* 2024-06-20

### PR 내용
- 수정사항
    - 자유게시판 type 이름 변경
        - 기존 : TIP  / FREE
        - 변경 후 : SAVING_TIPS / FREE
    - 정렬 type 이름 변경
        - 기존 : VIEW / LATEST
        - 변경 후 : VIEW_COUNT / LATEST
    - 조회수 중복 방지 해결
        - 동일한 사용자가 같은 커뮤니티 게시글을 조회했을 경우 기존 설계대로라면 하루가 지나지 않은 시점이라면 조회수가 1 증가 해야하는데 계속 증가되는 것을 확인했었음
        - redis에 값이 제대로 저장되고 있지 않았음
            - null+커뮤니티id ← 이 형식으로 저장되고 있었음
            - 최종 수정 후
                - user : ${userId} ← redis 키 값
                - value : {”커뮤니티 id”} ← set
                - ** 원래는 유저 id로만 key 값을 하려고 했으나 다른 게시글을 봤을 때 덮어씌워지는 문제점을 발견 → 유저 id + 커뮤니티 id 를 키 값으로 하여 문제를 해결했으나 이렇게 되면 키 값이 무수히 많아지는 문제점이 발생해 set으로 커뮤니티 id를 저장함